### PR TITLE
Testing

### DIFF
--- a/Re-ID Bot.ahk
+++ b/Re-ID Bot.ahk
@@ -162,8 +162,6 @@
 		if (Info.Settings.showimg) { ; If user wants images displayed
 			GuiControl, 1:, imagedisplay, % "HBITMAP:*" gc.hBitmap
 			}
-		DllCall("DeleteObject", "Ptr", gc.hBitmap) ; Clearing bitmap from memory
-		gc.hBitmap := "" ; Clearing variable content after bitmap
 		result := ""
 		for _,curr in StrSplit(gc.result, "`n", "`r") {
 			if !curr
@@ -177,6 +175,8 @@
 				goto, CheckAgain
 			}
 		Compare(Info, result, found, fixedresult, gc)
+		DllCall("DeleteObject", "Ptr", gc.hBitmap) ; Clearing bitmap from memory
+		gc.hBitmap := "" ; Clearing variable content after bitmap
 		GuiControl, 1:, outputdisplay, % fixedresult "`nTook " A_TickCount - Tick "ms with " Attempt " attempt" (Attempt > 1 ? "s":"") "."
 
 		if (found) { ; Found ID, stop re-iding

--- a/Re-ID Bot.ahk
+++ b/Re-ID Bot.ahk
@@ -175,8 +175,9 @@
 				goto, CheckAgain
 			}
 		Compare(Info, result, found, fixedresult, gc)
-		DllCall("DeleteObject", "Ptr", gc.hBitmap) ; Clearing bitmap from memory
-		gc.hBitmap := "" ; Clearing variable content after bitmap
+		DllCall("DeleteObject", "Ptr", gc.hBitmap) ; Clearing hbitmap from memory
+        Gdip_DisposeImage(gc.Bitmap)
+		gc.Bitmap := gc.hBitmap := "" ; Clearing variable content after (h)bitmap has been used.
 		GuiControl, 1:, outputdisplay, % fixedresult "`nTook " A_TickCount - Tick "ms with " Attempt " attempt" (Attempt > 1 ? "s":"") "."
 
 		if (found) { ; Found ID, stop re-iding

--- a/lib/Compare.ahk
+++ b/lib/Compare.ahk
@@ -3,7 +3,8 @@
 Compare(this, result, ByRef found := "", ByRef fixed := "", reocr := "") {
     unknownread:
     ; Manual fixes for things the Levenshtein Distance doesnt easily fix.
-    result := StrReplace(result, "0/0") ; Manual fixes
+    result := StrReplace(result, "0/0")
+    result := StrReplace(result, "070")
     result := StrReplace(result, "+ g", "+ 9")
     result := StrReplace(result, "DMge", "Dodge")
     result := StrReplace(result, "tix_ige", "Dodge")

--- a/lib/Compare.ahk
+++ b/lib/Compare.ahk
@@ -35,12 +35,7 @@ Compare(this, result, ByRef found := "", ByRef fixed := "", reocr := "") {
                 currid := FindString(currid) ; Correct OCR Errors
             
             if ((currnum = "UNKNOWN" || currid = -1) && reocr.ocrt = "win10") { ; Use Tesseract for weird ocr reads
-                reocr.ocrt := "tess4"
-                reocr.OCR()
-                DllCall("DeleteObject", "Ptr", reocr.hBitmap) ; Clearing bitmap from memory
-                reocr.hBitmap := "" ; Clearing variable content after bitmap
-                result := reocr.result
-                reocr.ocrt := "win10"
+                reocr.result := Vis2.OCR(reocr.Bitmap)
                 goto, unknownread
                 }
 

--- a/lib/Compare.ahk
+++ b/lib/Compare.ahk
@@ -34,7 +34,7 @@ Compare(this, result, ByRef found := "", ByRef fixed := "", reocr := "") {
                 currid := FindString(currid) ; Correct OCR Errors
             
             if ((currnum = "UNKNOWN" || currid = -1) && reocr.ocrt = "win10") { ; Use Tesseract for weird ocr reads
-                reocr.result := Vis2.OCR(reocr.Bitmap)
+                result := Vis2.OCR(reocr.Bitmap)
                 goto, unknownread
                 }
 

--- a/lib/Compare.ahk
+++ b/lib/Compare.ahk
@@ -7,6 +7,7 @@ Compare(this, result, ByRef found := "", ByRef fixed := "", reocr := "") {
     result := StrReplace(result, "+ g", "+ 9")
     result := StrReplace(result, "DMge", "Dodge")
     result := StrReplace(result, "tix_ige", "Dodge")
+    result := StrReplace(result, "Dcxfge", "Dodge")
 
     result := StrReplace(result, "-")
     result := StrReplace(result, "+")

--- a/lib/Compare.ahk
+++ b/lib/Compare.ahk
@@ -2,11 +2,15 @@
 #Include <FindString>
 Compare(this, result, ByRef found := "", ByRef fixed := "", reocr := "") {
     unknownread:
+    ; Manual fixes for things the Levenshtein Distance doesnt easily fix.
+    result := StrReplace(result, "0/0") ; Manual fixes
     result := StrReplace(result, "+ g", "+ 9")
+    result := StrReplace(result, "DMge", "Dodge")
+    result := StrReplace(result, "tix_ige", "Dodge")
+
     result := StrReplace(result, "-")
     result := StrReplace(result, "+")
     result := StrReplace(result, "%")
-    result := StrReplace(result, "0/0")
     resultarray := StrSplit(result, "`n", "`r")
 
     count := 0, found := 0, fixed := ""

--- a/lib/Compare.ahk
+++ b/lib/Compare.ahk
@@ -21,7 +21,6 @@ Compare(this, result, ByRef found := "", ByRef fixed := "", reocr := "") {
                 Continue ; Skip empty IDs
 
             currnum := 0
-
             for _,num in StrSplit(resultid, " ") { ; Finds Current ID's Number
                 if num is not integer
                     Continue

--- a/lib/MultiOCR.ahk
+++ b/lib/MultiOCR.ahk
@@ -97,11 +97,9 @@ Class MultiOCR {
                 DllCall("DeleteObject", "Ptr", pIRandomAccessStream)
             }
 
-            ; Gdip_SetBitmapToClipboard(this.Bitmap) ; Uncomment for Testing / Debug purposes 
-
-            ; After ocr
-            ; DllCall("DeleteObject", "Ptr", this.hBitmap)
-            Gdip_DisposeImage(this.Bitmap)
+            ; Remember to close out these after done using them!
+                ; DllCall("DeleteObject", "Ptr", this.hBitmap)
+                ; Gdip_DisposeImage(this.Bitmap)
             return this.result
             }
     ; =====

--- a/lib/Settings.ahk
+++ b/lib/Settings.ahk
@@ -3,6 +3,6 @@ If FileExist("Settings.json") {
     FileRead, tempjson, Settings.json
     Info := JSON.Load(tempjson), tempjson := ""
 } Else
-    Info := {GUI: {X: "ERROR", Y: "ERROR"}, Settings: {ocrengine: 2, savepos: 1, savetype: 1, showimg: 1, fixstats: 0, screendelay: 10, iddelay: 2680}, Field: {X: 0, Y: 0, W: 0, H: 0}, IDs: {Target: 0, IDButton: {X: 0, Y: 0}, ResetButton: {X: 0, Y: 0}, count: 3, idmode: 2, Types: [], Minimums: []}}
+    Info := {GUI: {X: "ERROR", Y: "ERROR"}, Settings: {ocrengine: 2, savepos: 1, savetype: 1, showimg: 1, fixstats: 0, screendelay: 10, iddelay: 2685}, Field: {X: 0, Y: 0, W: 0, H: 0}, IDs: {Target: 0, IDButton: {X: 0, Y: 0}, ResetButton: {X: 0, Y: 0}, count: 3, idmode: 2, Types: [], Minimums: []}}
 if (!Info.IDs.Minimums[1])
     change := 1 ; Used for Labels>Start


### PR DESCRIPTION
When Unknown ID or ID Number, it no longer takes a new screen-capture, it instead uses previous bitmap and sends it directly to tesseract for a new read.
Also fixed rare cases of Crit Dodge being misread as Crit Damage.